### PR TITLE
 fix nvcc error nothing to do with ""

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,17 @@ endif()
 
 set(CUDA_SEPARABLE_COMPILATION ON)
 
-set(CUDA_NVCC_FLAGS_DEBUG   "${CUDA_NVCC_FLAGS_DEBUG};-G;-g")
-set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-O3")
+# The following if should not be necessary, but apparently there is a bug in FindCUDA.cmake that
+# generate an empty string in the nvcc command line causing the compilation to fail.
+# see https://gitlab.kitware.com/cmake/cmake/issues/16411
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  message(STATUS "Building in debug mode")
+  set(CUDA_NVCC_FLAGS_DEBUG   "${CUDA_NVCC_FLAGS_DEBUG};-G;-g")
+else()
+  message(STATUS "Building in release mode")
+  set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-O3;-DNDEBUG")
+  # set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-G;-g;-DNDEBUG")
+endif()
 set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_30,code=sm_30")
 set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_35,code=sm_35")
 set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_50,code=sm_50")

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ make install
 ```
 
 Continuous integration: 
-- [![Build Status](https://travis-ci.org/poparteu/popsift.svg?branch=master)](https://travis-ci.org/poparteu/popsift) master branch.
-- [![Build Status](https://travis-ci.org/poparteu/popsift.svg?branch=develop)](https://travis-ci.org/poparteu/popsift) develop branch.
+- [![Build Status](https://travis-ci.org/alicevision/popsift.svg?branch=master)](https://travis-ci.org/poparteu/popsift) master branch.
+- [![Build Status](https://travis-ci.org/alicevision/popsift.svg?branch=develop)](https://travis-ci.org/poparteu/popsift) develop branch.
 
 
 


### PR DESCRIPTION
fixing what it seems to be a bug in FindCUDA.cmake that generates an empty string in the nvcc command line causing the compilation to fail "nothing to do with "" ".
see https://gitlab.kitware.com/cmake/cmake/issues/16411

* incidentally, it also fixes the README to take into account the recent switch to alicevision for showing travis status