### PR TITLE
pow() required explicit type (?)

### DIFF
--- a/src/popsift/gauss_filter.cu
+++ b/src/popsift/gauss_filter.cu
@@ -170,10 +170,10 @@ void init_filter( const Config& conf,
                 "    Input blurriness is assumed to be %f (scaled to %f)\n"
                 ,
                 conf.getUpscaleFactor(),
-                pow( 2.0, conf.getUpscaleFactor() ),
+                pow( 2.0f, conf.getUpscaleFactor() ),
                 sigma0,
                 conf.getInitialBlur(),
-                conf.getInitialBlur() * pow( 2.0, conf.getUpscaleFactor() )
+                conf.getInitialBlur() * pow( 2.0f, conf.getUpscaleFactor() )
                 );
         // printf("sigma is initially sigma0, afterwards the difference between previous 2 sigmas\n");
     }
@@ -187,13 +187,13 @@ void init_filter( const Config& conf,
     if( not conf.hasInitialBlur() ) {
         h_gauss.inc.sigma[0] = sigma0;
     } else {
-        const float initial_blur = conf.getInitialBlur() * pow( 2.0, conf.getUpscaleFactor() );
+        const float initial_blur = conf.getInitialBlur() * pow( 2.0f, conf.getUpscaleFactor() );
         h_gauss.inc.sigma[0] = sqrt( fabsf( sigma0 * sigma0 - initial_blur * initial_blur ) );
     }
 
     for( int lvl=1; lvl<h_gauss.required_filter_stages; lvl++ ) {
-        const float sigmaP = sigma0 * pow( 2.0, (float)(lvl-1)/(float)levels );
-        const float sigmaS = sigma0 * pow( 2.0, (float)(lvl  )/(float)levels );
+        const float sigmaP = sigma0 * pow( 2.0f, (float)(lvl-1)/(float)levels );
+        const float sigmaS = sigma0 * pow( 2.0f, (float)(lvl  )/(float)levels );
 
         h_gauss.inc.sigma[lvl] = sqrt( sigmaS * sigmaS - sigmaP * sigmaP );
     }
@@ -202,10 +202,10 @@ void init_filter( const Config& conf,
 
     float initial_blur = 0.0f;
     if( conf.hasInitialBlur() ) {
-        initial_blur = conf.getInitialBlur() * pow( 2.0, conf.getUpscaleFactor() );
+        initial_blur = conf.getInitialBlur() * pow( 2.0f, conf.getUpscaleFactor() );
     }
     for( int lvl=0; lvl<h_gauss.required_filter_stages; lvl++ ) {
-        const float sigmaS = sigma0 * pow( 2.0, (float)(lvl)/(float)levels );
+        const float sigmaS = sigma0 * pow( 2.0f, (float)(lvl)/(float)levels );
         h_gauss.abs_o0.sigma[lvl]  = sqrt( fabs( sigmaS * sigmaS - initial_blur * initial_blur ) );
     }
 
@@ -214,13 +214,13 @@ void init_filter( const Config& conf,
     if( not conf.hasInitialBlur() ) {
         h_gauss.inc_relative.sigma[0] = sigma0;
     } else {
-        const float initial_blur = conf.getInitialBlur() * pow( 2.0, conf.getUpscaleFactor() );
+        const float initial_blur = conf.getInitialBlur() * pow( 2.0f, conf.getUpscaleFactor() );
         h_gauss.inc_relative.sigma[0] = sqrt( fabsf( sigma0 * sigma0 - initial_blur * initial_blur ) );
     }
 
     for( int lvl=1; lvl<h_gauss.required_filter_stages; lvl++ ) {
-        const float sigmaP = sigma0 * pow( 2.0, (float)(lvl-1)/(float)levels );
-        const float sigmaS = sigma0 * pow( 2.0, (float)(lvl  )/(float)levels );
+        const float sigmaP = sigma0 * pow( 2.0f, (float)(lvl-1)/(float)levels );
+        const float sigmaS = sigma0 * pow( 2.0f, (float)(lvl  )/(float)levels );
 
         h_gauss.inc_relative.sigma[lvl] = sqrt( sigmaS * sigmaS - sigmaP * sigmaP );
     }
@@ -231,23 +231,23 @@ void init_filter( const Config& conf,
 #if 0
     if( conf.ifPrintGaussTables() ) {
         for( int lvl=0; lvl<h_gauss.required_filter_stages; lvl++ ) {
-            float sigmaP = sigma0 * pow( 2.0, (float)(lvl-1)/(float)levels );
-            float sigmaS = sigma0 * pow( 2.0, (float)(lvl  )/(float)levels );
+            float sigmaP = sigma0 * pow( 2.0f, (float)(lvl-1)/(float)levels );
+            float sigmaS = sigma0 * pow( 2.0f, (float)(lvl  )/(float)levels );
             if( lvl == 0 ) {
-                sigmaP = conf.getInitialBlur() * pow( 2.0, conf.getUpscaleFactor() );
+                sigmaP = conf.getInitialBlur() * pow( 2.0f, conf.getUpscaleFactor() );
             }
             printf("    Sigma (rel) for level %d: %2.6f = sqrt(sigmaS(%2.6f)^2 - sigmaP(%2.6f)^2)\n", lvl, h_gauss.inc.sigma[lvl], sigmaS, sigmaP );
         }
 
         for( int lvl=0; lvl<h_gauss.required_filter_stages; lvl++ ) {
-            const float sigmaS = sigma0 * pow( 2.0, (float)(lvl)/(float)levels );
+            const float sigmaS = sigma0 * pow( 2.0f, (float)(lvl)/(float)levels );
             printf("    Sigma (abs0) for level %d: %2.6f = sqrt(sigmaS(%2.6f)^2 - sigmaP(%2.6f)^2)\n", lvl, h_gauss.abs_o0.sigma[lvl], sigmaS, initial_blur );
         }
     }
 #endif
 
     for( int lvl=0; lvl<h_gauss.required_filter_stages; lvl++ ) {
-        const float sigmaS = sigma0 * pow( 2.0, (float)(lvl)/(float)levels );
+        const float sigmaS = sigma0 * pow( 2.0f, (float)(lvl)/(float)levels );
         h_gauss.abs_oN.sigma[lvl]  = sigmaS;
     }
     h_gauss.abs_oN.computeBlurTable( &h_gauss );

--- a/src/popsift/sift_pyramid.cu
+++ b/src/popsift/sift_pyramid.cu
@@ -331,9 +331,9 @@ void Pyramid::writeDescriptor( const Config& conf, ostream& ostr, Features* feat
     for( int ext_idx = 0; ext_idx<hct.ext_total; ext_idx++ ) {
         const Feature& ext = features->getFeatures()[ext_idx];
         const int   octave  = ext.debug_octave;
-        const float xpos    = ext.xpos  * pow(2.0, octave - up_fac);
-        const float ypos    = ext.ypos  * pow(2.0, octave - up_fac);
-        const float sigma   = ext.sigma * pow(2.0, octave - up_fac);
+        const float xpos    = ext.xpos  * pow(2.0f, octave - up_fac);
+        const float ypos    = ext.ypos  * pow(2.0f, octave - up_fac);
+        const float sigma   = ext.sigma * pow(2.0f, octave - up_fac);
         for( int ori = 0; ori<ext.num_ori; ori++ ) {
             // const int   ori_idx = ext.idx_ori + ori;
             float       dom_ori = ext.orientation[ori];


### PR DESCRIPTION
@griwodz I don't know if it is correct, anyway clang3.7 (and cuda7.5) was complaining about this because
```
sift_pyramid.cu(334): error: more than one instance of overloaded function "pow" matches the argument list:
            function template "std::__1::__lazy_enable_if<<expression>, std::__1::__promote<_A1, _A2, void>>::type std::__1::pow(_A1, _A2)"
            function template "std::__1::enable_if<<expression>, std::__1::__promote<_Tp, _Up, void>::type>::type std::__1::pow(_Tp, _Up)"
            argument types are: (double, float)

```

With this fix it shuts up and builds fine, didn't manage to make the demo working though, got something like this
```
./popsift-demo -i ~/Pictures/plant1.png 
plant1.png
Loading 1123 x 563 image plant1.png
popsift/src/popsift/s_extrema.cu:607
    cudaEventRecord failed: unspecified launch failure
```

But that may be on me and the mess I have at the moment on my machine. It is up to you, if you believe it does not harm u can merge otherwise discard this PR :-)

S.